### PR TITLE
Image transport

### DIFF
--- a/environment_ros2.yaml
+++ b/environment_ros2.yaml
@@ -16,7 +16,10 @@ dependencies:
 - ros-humble-joint-state-publisher
 - ros-humble-joint-state-publisher-gui
 - ros-humble-xacro
-- ros-humble*-image-transport*
+- ros-humble-image-transport
+- ros-humble-image-transport-plugins
+- ros-humble-compressed-depth-image-transport
+- ros-humble-compressed-image-transport
 - cmake
 - pkg-config
 - make

--- a/environment_ros2.yaml
+++ b/environment_ros2.yaml
@@ -16,6 +16,7 @@ dependencies:
 - ros-humble-joint-state-publisher
 - ros-humble-joint-state-publisher-gui
 - ros-humble-xacro
+- ros-humble*-image-transport*
 - cmake
 - pkg-config
 - make


### PR DESCRIPTION
To use the intel real sense with compressed images, we have to install some extra libraries into the environment.

See: https://github.com/IntelRealSense/realsense-ros/issues/2329